### PR TITLE
[REC] Make prep/bake accept DF and return DF

### DIFF
--- a/icu_benchmarks/recipes/ingredients.py
+++ b/icu_benchmarks/recipes/ingredients.py
@@ -7,9 +7,9 @@ import pandas as pd
 class Ingredients(pd.DataFrame):
     _metadata = ["roles"]
 
-    def __init__(self, data=None, index=None, columns=None, dtype=None, copy=None,):
-        super().__init__(data, index, columns, dtype, )
-        self.roles = {}
+    def __init__(self, data=None, index=None, columns=None, dtype=None, copy=None, roles = {}):
+        super().__init__(data, index, columns, dtype, copy, )
+        self.roles = roles
 
     @property
     def _constructor(self):

--- a/icu_benchmarks/recipes/main.py
+++ b/icu_benchmarks/recipes/main.py
@@ -16,6 +16,6 @@ if __name__ == "__main__":
     rec.add_step(StepImputeFill(method='ffill'))
     rec.add_step(StepImputeFill(value=0))
     
-    rec.prep()
-    rec.bake()
+    rec.prep(df.iloc[:-10000, :])
+    rec.bake(df.iloc[10000:, :])
 

--- a/icu_benchmarks/recipes/recipe.py
+++ b/icu_benchmarks/recipes/recipe.py
@@ -39,6 +39,8 @@ class Recipe():
     def _check_data(self, data):
         if data is None:
             data = self.data
+        elif data.__class__ == pd.DataFrame:
+            data = Ingredients(data, roles=self.data.roles)
         if not data.columns.equals(self.data.columns):
             raise ValueError('Columns of data argument differs from recipe data.')
         return data
@@ -60,12 +62,12 @@ class Recipe():
             else:
                 data = step.transform(data)
 
-        return self
+        return pd.DataFrame(data)
 
     def bake(self, data=None):
         data = self._check_data(data)
         data = copy(data)
-
+        
         for step in self.steps:
             data = self._apply_group(data, step)
             if not step.trained:
@@ -73,7 +75,7 @@ class Recipe():
             else:
                 data = step.transform(data)
 
-        return data
+        return pd.DataFrame(data)
 
     def __repr__(self):
         repr = 'Recipe\n\n'


### PR DESCRIPTION
In R, `prep()` returns a `Recipe`. We will take a different (more efficient) approach here and change the `Recipe` directly, returning the transformed training data as a `pandas.DataFrame`.