### PR TITLE
Add sequence role

### DIFF
--- a/icu_benchmarks/recipes/recipe.py
+++ b/icu_benchmarks/recipes/recipe.py
@@ -9,7 +9,7 @@ from icu_benchmarks.recipes.selector import groups
 
 
 class Recipe():
-    def __init__(self, data, outcomes=None, predictors=None, groups=None) -> None:
+    def __init__(self, data, outcomes=None, predictors=None, groups=None, sequences=None) -> None:
         self.data = Ingredients(data)
         self.steps = []
 
@@ -19,6 +19,8 @@ class Recipe():
             self.add_role(predictors, 'predictor')
         if groups:
             self.add_role(groups, 'group')
+        if sequences:
+            self.add_role(sequences, 'sequence')
 
     def add_role(self, vars, new_role='predictor'):
         if isinstance(vars, str):


### PR DESCRIPTION
This adds the functionality described in #12 .

Our main use case for this role will be marking the time step variable (e.g., hour). Renamed this into `"sequence"` to be more general and also highlight that this is meant to be discrete rather than continuous. Also refrained from calling it index (like is the case in the R package ricu) to avoid confusion with pandas indices. 