### PR TITLE
Fixes + Convenience updates [Vectorized ram_cache, multi label padding, debug sampling]

### DIFF
--- a/icu_benchmarks/data/loader.py
+++ b/icu_benchmarks/data/loader.py
@@ -130,21 +130,29 @@ class PredictionPolarsDataset(CommonPolarsDataset):
 
         if len(labels) == 1:
             # only one label per stay, align with window
-            labels = np.concatenate([np.empty(window.shape[0] - 1) * np.nan, labels], axis=0)
+            labels = np.concatenate(
+                [np.full((window.shape[0] - 1, *labels.shape[1:]), np.nan), labels],
+                axis=0,
+            )
 
         length_diff = self.maxlen - window.shape[0]
         pad_mask = np.ones(window.shape[0])
 
         # Padding the array to fulfill size requirement
         if length_diff > 0:
-            window = np.concatenate([window, np.ones((length_diff, window.shape[1])) * pad_value], axis=0)
-            labels = np.concatenate([labels, np.ones(length_diff) * pad_value], axis=0)
+            window = np.concatenate([window, np.full((length_diff, window.shape[1]), pad_value)], axis=0)
+            labels = np.concatenate([labels, np.full((length_diff, *labels.shape[1:]), pad_value)], axis=0)
             pad_mask = np.concatenate([pad_mask, np.zeros(length_diff)], axis=0)
 
-        not_labeled = np.argwhere(np.isnan(labels))
-        if len(not_labeled) > 0:
-            labels[not_labeled] = -1
-            pad_mask[not_labeled] = 0
+        # check for (partially) unlabeled data
+        nan_mask = np.isnan(labels)
+        labels[nan_mask] = -1
+        invalid_rows = (
+            nan_mask
+            if labels.ndim == 1
+            else nan_mask.any(axis=-1)
+        )
+        pad_mask[invalid_rows] = 0
 
         pad_mask = pad_mask.astype(bool)
         labels = labels.astype(np.float32)

--- a/icu_benchmarks/data/loader.py
+++ b/icu_benchmarks/data/loader.py
@@ -47,6 +47,14 @@ class CommonPolarsDataset(Dataset):
             logging.info("Using static dataset")
             self.row_indicators = data[split][DataSegment.features][self.vars["GROUP"]]
             self.features_df = data[split][DataSegment.features]
+
+        # order columns: index, features (alphabetically), indicator (alphabetically)
+        cols = self.features_df.columns
+        m_index = [self.vars["GROUP"]]
+        front = sorted([c for c in cols if not c.startswith("MissingIndicator_") and c not in m_index])
+        back = sorted([c for c in cols if c.startswith("MissingIndicator_") and c not in m_index])
+        self.features_df= self.features_df[m_index + front + back]
+
         # calculate basic info for the data
         self.num_stays = self.grouping_df[self.vars["GROUP"]].unique().shape[0]
         self.maxlen = self.features_df.group_by([self.vars["GROUP"]]).len().max().item(0, 1)

--- a/icu_benchmarks/data/loader.py
+++ b/icu_benchmarks/data/loader.py
@@ -53,7 +53,7 @@ class CommonPolarsDataset(Dataset):
         m_index = [self.vars["GROUP"]]
         front = sorted([c for c in cols if not c.startswith("MissingIndicator_") and c not in m_index])
         back = sorted([c for c in cols if c.startswith("MissingIndicator_") and c not in m_index])
-        self.features_df= self.features_df[m_index + front + back]
+        self.features_df = self.features_df[m_index + front + back]
 
         # calculate basic info for the data
         self.num_stays = self.grouping_df[self.vars["GROUP"]].unique().shape[0]
@@ -107,15 +107,12 @@ class PredictionPolarsDataset(CommonPolarsDataset):
         feat_partitions = self.features_df.partition_by(GROUP, maintain_order=True)
         self._stay_order = [part[GROUP][0] for part in label_partitions]
         self._feat_arrays = {
-            part[GROUP][0]: part.select(pl.exclude(GROUP)).to_numpy().astype(np.float32)
-            for part in feat_partitions
+            part[GROUP][0]: part.select(pl.exclude(GROUP)).to_numpy().astype(np.float32) for part in feat_partitions
         }
         for arr in self._feat_arrays.values():
             arr.setflags(write=False)
-    
-        self._label_arrays = {
-            part[GROUP][0]: part[LABEL].to_numpy().astype(np.float32) for part in label_partitions
-        }
+
+        self._label_arrays = {part[GROUP][0]: part[LABEL].to_numpy().astype(np.float32) for part in label_partitions}
         for arr in self._label_arrays.values():
             arr.setflags(write=False)
 
@@ -126,7 +123,7 @@ class PredictionPolarsDataset(CommonPolarsDataset):
         stay_id = self._stay_order[idx]
 
         window = self._feat_arrays[stay_id]
-        labels = self._label_arrays[stay_id].copy() # copy to avoid in-place NaN replacement
+        labels = self._label_arrays[stay_id].copy()  # copy to avoid in-place NaN replacement
 
         if len(labels) == 1:
             # only one label per stay, align with window
@@ -147,11 +144,7 @@ class PredictionPolarsDataset(CommonPolarsDataset):
         # check for (partially) unlabeled data
         nan_mask = np.isnan(labels)
         labels[nan_mask] = -1
-        invalid_rows = (
-            nan_mask
-            if labels.ndim == 1
-            else nan_mask.any(axis=-1)
-        )
+        invalid_rows = nan_mask if labels.ndim == 1 else nan_mask.any(axis=-1)
         pad_mask[invalid_rows] = 0
 
         pad_mask = pad_mask.astype(bool)

--- a/icu_benchmarks/data/preprocessor.py
+++ b/icu_benchmarks/data/preprocessor.py
@@ -312,7 +312,7 @@ class PolarsRegressionPreprocessor(PolarsClassificationPreprocessor):
                 outcome_rec.add_step(
                     StepSklearn(
                         sklearn_transformer=FunctionTransformer(
-                            func=lambda x: ((x - self.outcome_min) / (self.outcome_max - self.outcome_min))
+                            func=lambda x: (x - self.outcome_min) / (self.outcome_max - self.outcome_min)
                         ),
                         sel=all_outcomes(),
                     )
@@ -528,7 +528,7 @@ class PandasRegressionPreprocessor(PandasClassificationPreprocessor):
             outcome_rec.add_step(
                 StepSklearn(
                     sklearn_transformer=FunctionTransformer(
-                        func=lambda x: ((x - self.outcome_min) / (self.outcome_max - self.outcome_min))
+                        func=lambda x: (x - self.outcome_min) / (self.outcome_max - self.outcome_min)
                     ),
                     sel=all_outcomes(),
                 )

--- a/icu_benchmarks/data/split_process_data.py
+++ b/icu_benchmarks/data/split_process_data.py
@@ -368,15 +368,13 @@ def make_train_val_polars(
         )
 
     if debug:
-        logging.info(
-            "Using only 1% of the stay_id's for debugging. Note that this might lead to errors for small datasets."
-        )
+        logging.info("Using only 1% of the stay_id's for debugging. Note that this might lead to errors for small datasets.")
         sampled_ids = data[DataSegment.outcome][_id].unique().sample(fraction=0.01, seed=seed)
         data[DataSegment.outcome].filter(pl.col(_id).is_in(sampled_ids))
         if DataSegment.dynamic in data:
-             data[DataSegment.dynamic] = data[DataSegment.dynamic].filter(pl.col(_id).is_in(sampled_ids))
+            data[DataSegment.dynamic] = data[DataSegment.dynamic].filter(pl.col(_id).is_in(sampled_ids))
         if DataSegment.static in data:
-             data[DataSegment.static] = data[DataSegment.static].filter(pl.col(_id).is_in(sampled_ids))
+            data[DataSegment.static] = data[DataSegment.static].filter(pl.col(_id).is_in(sampled_ids))
 
     stays = pl.Series(name=_id, values=data[DataSegment.outcome][_id].unique())
 
@@ -544,9 +542,7 @@ def make_single_split_polars(
     # ID variable
     _id = vars[VarType.group]
     if debug:
-        logging.info(
-            "Using only 1% of the stay_id's for debugging. Note that this might lead to errors for small datasets."
-        )
+        logging.info("Using only 1% of the stay_id's for debugging. Note that this might lead to errors for small datasets.")
         sampled_ids = data[DataSegment.outcome][_id].unique().sample(fraction=0.01, seed=seed)
         data[DataSegment.outcome] = data[DataSegment.outcome].filter(pl.col(_id).is_in(sampled_ids))
         if DataSegment.dynamic in data:

--- a/icu_benchmarks/data/split_process_data.py
+++ b/icu_benchmarks/data/split_process_data.py
@@ -368,8 +368,15 @@ def make_train_val_polars(
         )
 
     if debug:
-        logging.info("Using only 1% of the data for debugging. Note that this might lead to errors for small datasets.")
-        data[DataSegment.outcome] = data[DataSegment.outcome].sample(fraction=0.01, seed=seed)
+        logging.info(
+            "Using only 1% of the stay_id's for debugging. Note that this might lead to errors for small datasets."
+        )
+        sampled_ids = data[DataSegment.outcome][_id].unique().sample(fraction=0.01, seed=seed)
+        data[DataSegment.outcome].filter(pl.col(_id).is_in(sampled_ids))
+        if DataSegment.dynamic in data:
+             data[DataSegment.dynamic] = data[DataSegment.dynamic].filter(pl.col(_id).is_in(sampled_ids))
+        if DataSegment.static in data:
+             data[DataSegment.static] = data[DataSegment.static].filter(pl.col(_id).is_in(sampled_ids))
 
     stays = pl.Series(name=_id, values=data[DataSegment.outcome][_id].unique())
 
@@ -535,18 +542,24 @@ def make_single_split_polars(
     For a more detailed documentation refer to make_single_splits(...)
     """
     # ID variable
-    id = vars[VarType.group]
+    _id = vars[VarType.group]
     if debug:
-        # Only use 1% of the data
-        logging.info("Using only 1% of the data for debugging. Note that this might lead to errors for small datasets.")
-        data[DataSegment.outcome] = data[DataSegment.outcome].sample(fraction=0.01, seed=seed)
+        logging.info(
+            "Using only 1% of the stay_id's for debugging. Note that this might lead to errors for small datasets."
+        )
+        sampled_ids = data[DataSegment.outcome][_id].unique().sample(fraction=0.01, seed=seed)
+        data[DataSegment.outcome] = data[DataSegment.outcome].filter(pl.col(_id).is_in(sampled_ids))
+        if DataSegment.dynamic in data:
+            data[DataSegment.dynamic] = data[DataSegment.dynamic].filter(pl.col(_id).is_in(sampled_ids))
+        if DataSegment.static in data:
+            data[DataSegment.static] = data[DataSegment.static].filter(pl.col(_id).is_in(sampled_ids))
 
     # Get stay IDs from outcome segment
-    stays = pl.Series(name=id, values=data[DataSegment.outcome][id].unique())
+    stays = pl.Series(name=_id, values=data[DataSegment.outcome][_id].unique())
     # If there are labels, and the task is classification, use stratified k-fold
     if VarType.label in vars and runmode is RunMode.classification:
         # Get labels from outcome data (takes the highest value (or True) in case seq2seq classification)
-        labels: pl.Series = data[DataSegment.outcome].group_by(id).max().sort(id)[vars[VarType.label]]
+        labels: pl.Series = data[DataSegment.outcome].group_by(_id).max().sort(_id)[vars[VarType.label]]
         if labels.value_counts().min().item(0, 1) < cv_folds:
             raise Exception(
                 f"The smallest amount of samples in a class is: {labels.value_counts().min()}, "
@@ -586,8 +599,8 @@ def make_single_split_polars(
         # set sort to true to make sure that IDs are reordered after scrambling earlier
         data_split[fold] = {
             data_type: split[fold]
-            .join(data[data_type].with_columns(pl.col(id).cast(pl.datatypes.Int64)), on=id, how="left")
-            .sort(by=id)
+            .join(data[data_type].with_columns(pl.col(_id).cast(pl.datatypes.Int64)), on=_id, how="left")
+            .sort(by=_id)
             for data_type in data.keys()
         }
 

--- a/icu_benchmarks/data/split_process_data.py
+++ b/icu_benchmarks/data/split_process_data.py
@@ -370,7 +370,7 @@ def make_train_val_polars(
     if debug:
         logging.info("Using only 1% of the stay_id's for debugging. Note that this might lead to errors for small datasets.")
         sampled_ids = data[DataSegment.outcome][_id].unique().sample(fraction=0.01, seed=seed)
-        data[DataSegment.outcome].filter(pl.col(_id).is_in(sampled_ids))
+        data[DataSegment.outcome] = data[DataSegment.outcome].filter(pl.col(_id).is_in(sampled_ids))
         if DataSegment.dynamic in data:
             data[DataSegment.dynamic] = data[DataSegment.dynamic].filter(pl.col(_id).is_in(sampled_ids))
         if DataSegment.static in data:
@@ -551,7 +551,7 @@ def make_single_split_polars(
             data[DataSegment.static] = data[DataSegment.static].filter(pl.col(_id).is_in(sampled_ids))
 
     # Get stay IDs from outcome segment
-    stays = pl.Series(name=_id, values=data[DataSegment.outcome][_id].unique())
+    stays = pl.Series(name=_id, values=data[DataSegment.outcome][_id].unique()).sort()
     # If there are labels, and the task is classification, use stratified k-fold
     if VarType.label in vars and runmode is RunMode.classification:
         # Get labels from outcome data (takes the highest value (or True) in case seq2seq classification)

--- a/icu_benchmarks/data/split_process_data.py
+++ b/icu_benchmarks/data/split_process_data.py
@@ -191,7 +191,7 @@ def preprocess_data(
             sel = _dict[key].select(pl.all().has_nulls())
             logging.debug(sel.select(col.name for col in sel if col.item(0)))
             _dict[key] = val.fill_null(strategy="zero")
-            _dict[key] = val.fill_nan(0)
+            _dict[key] = _dict[key].fill_nan(0)
             logging.debug("Dropping columns with nulls")
             sel = _dict[key].select(pl.all().has_nulls())
             logging.debug(sel.select(col.name for col in sel if col.item(0)))

--- a/icu_benchmarks/data/split_process_data.py
+++ b/icu_benchmarks/data/split_process_data.py
@@ -173,7 +173,7 @@ def preprocess_data(
         )
     else:
         # If full train is set, we use all data for training/validation
-        sanitized_data = make_train_val_polars(data, vars, train_size=None, seed=seed, debug=debug, runmode=runmode)
+        sanitized_data = make_train_val_polars(data, vars, train_size=train_size, seed=seed, debug=debug, runmode=runmode)
 
     # Apply preprocessing
     start = timer()


### PR DESCRIPTION
Summary:

1. allow to specify `train_size` when `complete_train=True`
2. fix overwrite instead of update error and debug sampling
3. use inner joins instead of left, should avoid unwanted null-rows
4. column names are now ordered alphabetically
5. updated padding logic in PolarDatasets, can now take more than one label (should be unchanged if only one label used)
6. buildup in PolarsPredictionDataset now uses a vectorized scheme offering massive speedup

(only touched the polars paths, deprecated pandas is unchanged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RAM cache functionality for faster dataset loading.

* **Bug Fixes**
  * Fixed train/validation split behavior when complete training is enabled.
  * Improved handling of missing label values (NaNs normalized; invalid labels masked).
  * Enhanced debug-mode sampling to better represent per-stay data.

* **Improvements**
  * Standardized dataset feature column ordering for consistency.
  * Simplified preprocessing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->